### PR TITLE
Fix benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This tool takes **APK** files as input. You can use `Python main.py --help` to c
 
 ## Limitation
 + to analyze a certain JNI function (i.e., functions in native code which have counterpart methods in VM code) or *JNI_OnLoad* function for dynamic registration of JNI functions, the time limit is set to 180 600 seconds respectively. Thus, for large JNI functions, the result could be missing. To increase the analysis time limit, reset the `WAIT_TIME` and `DYNAMIC_ANALYSIS_TIME` value in `main.py`.
-+ this tool is developed based on [Angr](https://angr.io/) framework. To avoid the analysis to go too deep into the path of a state, the [`LengthLimiter`](https://docs.angr.io/core-concepts/pathgroups) is set to 500 and 1000 repectively for analyzing JNI functions and *JNI_OnLoad*. This value can be adjusted by reset the `MAX_LENGTH` and `DYNAMIC_ANALYSIS_LENGTH` value in `jni_interfaces/utils.py`.
++ this tool is developed based on [Angr](https://angr.io/) framework. To avoid the analysis to go too deep into the path of a state, the [`LengthLimiter`](https://docs.angr.io/core-concepts/pathgroups) is set to 500000 and 100000 repectively for analyzing JNI functions and *JNI_OnLoad*. This value can be adjusted by reset the `MAX_LENGTH` and `DYNAMIC_ANALYSIS_LENGTH` value in `jni_interfaces/utils.py`.
 
 # Output
 For app named *example-app.apk*, by default, a folder named *example-app_result* will be created. In this folder, for each *shared library* file in the APK which contains JNI functions invoked by VM code, a counterpart result file will be generated with suffix *\*.result*. The result files are CSV files with following fields:

--- a/import_implementations.py
+++ b/import_implementations.py
@@ -1,0 +1,45 @@
+import logging
+
+from angr import SimProcedure
+from angr.procedures.libc.memcpy import memcpy
+from cle import SymbolType
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+class ReturnZero(SimProcedure):
+    def run(self):
+        self.ret(0)
+
+class UnimplementedHook(SimProcedure):
+    def __init__(self, symbol_name, *args, **kwargs):
+        super(UnimplementedHook, self).__init__(*args, **kwargs)
+        self.symbol_name = symbol_name
+
+    def run(self):
+        logger.warning("Symbol '%s' called but corresponding function is NOT implemented." % self.symbol_name)
+        self.ret()
+
+# Symbol name, SimProcedure
+IMPLEMENTED_IMPORTS = [
+    ("pthread_mutex_lock", ReturnZero),
+    ("pthread_mutex_unlock", ReturnZero),
+    ("__aeabi_memcpy", memcpy)
+    ]
+
+def hookAllImportSymbols(proj):
+    # Set hook on implemented imports
+    for symbName, SimProc in IMPLEMENTED_IMPORTS:
+        if proj.loader.find_symbol(symbName):
+            proj.hook_symbol(symbName, SimProc(), replace=True)
+
+    # Set warning SimProcedure on unimplemented imports
+    for symb in proj.loader.symbols :
+        if symb.is_import and symb.type == SymbolType.TYPE_FUNCTION:
+            symb_addr = symb.resolvedby.rebased_addr
+            if proj.is_hooked(symb_addr):
+                simProc = proj.hooked_by(symb_addr)
+                if not simProc.is_stub:
+                    # This symbol is already implemented by a SimProcedure
+                    continue
+            proj.hook_symbol(symb.name,  UnimplementedHook(symb.name), replace=True)

--- a/jni_interfaces/utils.py
+++ b/jni_interfaces/utils.py
@@ -14,8 +14,8 @@ from .record import Record, RecordNotFoundError
 JNI_LOADER = 'JNI_OnLoad'
 # value for "LengthLimiter" to limit the length of path a state goes through.
 # refer to: https://docs.angr.io/core-concepts/pathgroups
-MAX_LENGTH = 500
-DYNAMIC_ANALYSIS_LENGTH = 1000
+MAX_LENGTH = 500000
+DYNAMIC_ANALYSIS_LENGTH = 100000
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import cle
 import logging
 from androguard.misc import AnalyzeAPK
 
+from import_implementations import hookAllImportSymbols
 from jni_interfaces.record import Record
 from jni_interfaces.utils import (record_static_jni_functions, clean_records,
         record_dynamic_jni_functions, print_records, analyze_jni_function,
@@ -288,6 +289,7 @@ def find_all_jni_functions(so_file, dex):
         logger.warning(f'{so_file} cause CLE loader error: {e}')
     else:
         proj = angr.Project(cle_loader)
+        hookAllImportSymbols(proj)
         jvm_ptr, jenv_ptr = jni_env_prepare_in_object(proj)
         clean_records()
         record_static_jni_functions(proj, dex)


### PR DESCRIPTION
Benchmarks were failing due to a too low `LengthLimiter` threshold and some missing implementations of imported functions.
These commits fix these issues.